### PR TITLE
Stabilize Turkish frontend quiz state machine

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -283,3 +283,25 @@
 
 ### Remaining
 - **~600 lines code duplication in `games/strictbrain/js/game.js`** — Each of 5 mini-games is fully duplicated for single-player and versus mode. Only difference: target DOM element IDs and score update callbacks. Works correctly but is a maintenance burden. Future refactor could parameterize game functions with `{ area, onScore, onFinish }` config objects.
+
+---
+
+# HANDOFF - Turkish Quiz State Machine Stabilization
+
+## What Was Done
+
+- Added explicit quiz session state in `games/turkish/js/game.js` via `quizEnded` and `answerTimeoutId`.
+- Added central `resetQuizState()` called at quiz start to reset flags and clear any lingering interval/timeout handles.
+- Updated `renderQuestion()` to return early when the quiz has already ended.
+- Updated `handleAnswer()` to guard against post-end processing and to store the answer transition timeout handle.
+- Updated `endQuiz()` to be idempotent, set `quizEnded = true`, stop the interval timer, and clear any pending answer timeout.
+
+## Files Changed
+
+- `games/turkish/js/game.js`
+- `HANDOFF.md`
+
+## Verification
+
+- `node --check games/turkish/js/game.js`
+

--- a/games/turkish/js/game.js
+++ b/games/turkish/js/game.js
@@ -9,6 +9,8 @@
     let currentQ = 0;
     let score = 0;
     let timer = null;
+    let answerTimeoutId = null;
+    let quizEnded = false;
     let timeLeft = QUIZ_TIME;
 
     // ===== Screen Management =====
@@ -48,6 +50,7 @@
 
     // ===== Quiz =====
     function startQuiz() {
+        resetQuizState();
         quiz = lesson.quiz;
         currentQ = 0;
         score = 0;
@@ -58,6 +61,10 @@
     }
 
     function renderQuestion() {
+        if (quizEnded === true) {
+            return;
+        }
+
         if (currentQ >= quiz.length) {
             endQuiz();
             return;
@@ -80,6 +87,10 @@
     }
 
     function handleAnswer(selected, correct) {
+        if (quizEnded === true) {
+            return;
+        }
+
         const opts = $('quiz-options').querySelectorAll('.quiz-option');
         opts.forEach(btn => {
             btn.classList.add('disabled');
@@ -96,7 +107,10 @@
             $('quiz-feedback').style.color = '#cc3333';
         }
 
-        setTimeout(function () {
+        answerTimeoutId = setTimeout(function () {
+            if (quizEnded === true) {
+                return;
+            }
             currentQ++;
             renderQuestion();
         }, 1200);
@@ -127,9 +141,30 @@
         }
     }
 
+    function resetQuizState() {
+        quizEnded = false;
+        stopTimer();
+
+        if (answerTimeoutId !== null) {
+            clearTimeout(answerTimeoutId);
+            answerTimeoutId = null;
+        }
+    }
+
     // ===== Results =====
     function endQuiz() {
+        if (quizEnded === true) {
+            return;
+        }
+
+        quizEnded = true;
         stopTimer();
+
+        if (answerTimeoutId !== null) {
+            clearTimeout(answerTimeoutId);
+            answerTimeoutId = null;
+        }
+
         showScreen('result');
 
         const total = quiz.length;


### PR DESCRIPTION
### Motivation
- Prevent late timer/timeout callbacks from advancing the quiz or updating the UI after the session has ended, which could produce inconsistent or duplicated behavior.

### Description
- Added `quizEnded` and `answerTimeoutId` to `games/turkish/js/game.js` to track session end and the pending answer transition timeout.
- Added `resetQuizState()` and call it from `startQuiz()` to centrally clear timers/timeouts and initialize session state for a new round.
- Guarded `renderQuestion()` and `handleAnswer()` with early-returns when `quizEnded === true` and store the delayed answer transition in `answerTimeoutId` so it can be cleared.
- Made `endQuiz()` idempotent by setting `quizEnded = true`, stopping the interval timer, and clearing any pending answer timeout before rendering results.

### Testing
- Ran `node --check games/turkish/js/game.js`, which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ba49894c832fafff6d50f3770e9f)