### PR TITLE
Improve Turkish lesson startup UX when /api/turkish/daily fails

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -283,3 +283,35 @@
 
 ### Remaining
 - **~600 lines code duplication in `games/strictbrain/js/game.js`** — Each of 5 mini-games is fully duplicated for single-player and versus mode. Only difference: target DOM element IDs and score update callbacks. Works correctly but is a maintenance burden. Future refactor could parameterize game functions with `{ area, onScore, onFinish }` config objects.
+
+---
+
+# HANDOFF - Turkish Startflow Error State
+
+## What Was Done
+
+- Improved lesson loading resilience in `games/turkish/js/game.js`:
+  - Added explicit `res.ok` check before parsing successful payload.
+  - Added user-facing error state renderer (`setLoadError`) and start-button gating (`setStartButtonEnabled`).
+  - Added retry action wiring (`btn-retry-lesson`) to re-run `loadLesson()`.
+  - Ensured quiz cannot start while no lesson is loaded.
+- Added learn-screen error UI in `games/turkish/index.html`:
+  - New error container with clear message area and `Erneut versuchen` button.
+  - Start button is now disabled by default and styled for disabled state.
+- Standardized `/api/turkish/daily` failures in `server/index.js` with a structured JSON shape:
+  - `{ error: 'turkish_daily_failed', message: 'Daily lesson could not be generated.' }`
+
+## Files Changed
+
+- `games/turkish/js/game.js`
+- `games/turkish/index.html`
+- `server/index.js`
+- `PLANS.md`
+- `HANDOFF.md`
+
+## Verification
+
+- `node --check games/turkish/js/game.js`
+- `node --check server/index.js`
+- `npm test` *(fails in this environment because `vitest` is not installed)*
+- Manual browser check with mocked `500` response on `/api/turkish/daily` confirms visible error message, retry button, and disabled start button.

--- a/PLANS.md
+++ b/PLANS.md
@@ -18,9 +18,9 @@ Key files and modules involved, with paths.
 
 ## Progress
 - [ ] Start plan
-- [ ] Implement changes
-- [ ] Verify behavior
-- [ ] Update handoff notes
+- [x] Implement changes
+- [x] Verify behavior
+- [x] Update handoff notes
 
 ## Surprises and Discoveries
 List anything unexpected you learned while working.
@@ -35,3 +35,46 @@ Exact commands or manual steps to validate the change.
 
 ## Outcomes
 Summarize what shipped and what remains.
+
+---
+
+## ExecPlan - Turkish Startflow Error Handling (2026-02-07)
+
+## Purpose
+Improve the Turkish game startup UX when `/api/turkish/daily` fails by surfacing an actionable error state and allowing retry.
+
+## Scope
+- In scope: learn-screen error UI, retry action, start button disabled logic, and safer fetch error handling.
+- Optional in scope: standardize API error payload for `/api/turkish/daily` failures.
+- Out of scope: quiz mechanics, lesson content generation, visual redesign beyond minimal error container.
+
+## Context
+- `games/turkish/js/game.js`
+- `games/turkish/index.html`
+- `server/index.js`
+
+## Plan of Work
+1. Add explicit HTTP status check in `loadLesson()` and wire a reusable error-state renderer.
+2. Add learn-screen error container + retry button in HTML/CSS and connect it in JS.
+3. Disable `btn-start-quiz` while lesson is unavailable and keep it enabled only after successful load.
+4. Standardize server error response to `{ error, message }` in the Turkish daily endpoint.
+
+## Progress
+- [x] Start plan
+- [x] Implement changes
+- [x] Verify behavior
+- [x] Update handoff notes
+
+## Surprises and Discoveries
+- None yet.
+
+## Decision Log
+- Decision: Include optional server standardization because it improves client-side diagnostics with minimal risk.
+  Rationale: Single endpoint and additive JSON fields; no client break expected.
+  Date: 2026-02-07
+
+## Verification
+- Run targeted syntax checks and test suite.
+
+## Outcomes
+- Shipped client-side error handling + retry UX for Turkish lesson startup and standardized server error response payload.

--- a/games/turkish/index.html
+++ b/games/turkish/index.html
@@ -149,6 +149,45 @@
             background: var(--ds-text-dim);
         }
 
+        .btn-start:disabled {
+            background: var(--ds-highlight);
+            color: var(--ds-text-dim);
+            cursor: not-allowed;
+        }
+
+        .lesson-error {
+            display: none;
+            background: #ffe9e9;
+            border: 2px solid var(--ds-negative);
+            padding: 10px 12px;
+            margin-bottom: 12px;
+        }
+
+        .lesson-error.active {
+            display: block;
+        }
+
+        .lesson-error-message {
+            font-size: 9px;
+            color: #8e1d1d;
+            margin-bottom: 8px;
+            line-height: 1.7;
+        }
+
+        .btn-retry {
+            background: var(--ds-surface);
+            border: 2px solid var(--ds-negative);
+            color: #8e1d1d;
+            font-family: 'Press Start 2P', monospace;
+            font-size: 9px;
+            padding: 8px 10px;
+            cursor: pointer;
+        }
+
+        .btn-retry:hover {
+            background: #ffd6d6;
+        }
+
         /* Timer Bar */
         .timer-bar-wrap {
             background: var(--ds-highlight);
@@ -312,9 +351,14 @@
             <div class="lesson-day" id="lesson-day"></div>
         </div>
 
+        <div class="lesson-error" id="lesson-error">
+            <div class="lesson-error-message" id="lesson-error-message"></div>
+            <button class="btn-retry" id="btn-retry-lesson" type="button">Erneut versuchen</button>
+        </div>
+
         <div class="word-list" id="word-list"></div>
 
-        <button class="btn-start" id="btn-start-quiz">START QUIZ ▶</button>
+        <button class="btn-start" id="btn-start-quiz" disabled>START QUIZ ▶</button>
     </div>
 
     <!-- QUIZ SCREEN -->

--- a/games/turkish/js/game.js
+++ b/games/turkish/js/game.js
@@ -20,14 +20,45 @@
 
     // ===== Fetch Daily Lesson =====
     async function loadLesson() {
+        setLoadError('');
+        setStartButtonEnabled(false);
+
         try {
             const res = await fetch('/api/turkish/daily');
+            if (!res.ok) {
+                const payload = await res.json().catch(function () { return null; });
+                const message = payload && payload.message ? payload.message : 'Could not load lesson.';
+                throw new Error(message);
+            }
+
             lesson = await res.json();
             renderLesson();
+            setStartButtonEnabled(true);
         } catch (err) {
+            lesson = null;
             $('lesson-topic').textContent = 'Could not load lesson';
+            $('lesson-day').textContent = 'Please try again.';
+            $('word-list').innerHTML = '';
+            setLoadError(err && err.message ? err.message : 'Could not load lesson.');
+            setStartButtonEnabled(false);
             console.error('Failed to load lesson:', err);
         }
+    }
+
+
+    function setLoadError(message) {
+        const box = $('lesson-error');
+        const text = $('lesson-error-message');
+        const hasMessage = !!message;
+
+        if (text) text.textContent = message || '';
+        if (box) box.classList.toggle('active', hasMessage);
+    }
+
+    function setStartButtonEnabled(enabled) {
+        const btn = $('btn-start-quiz');
+        if (!btn) return;
+        btn.disabled = !enabled;
     }
 
     function renderLesson() {
@@ -48,6 +79,8 @@
 
     // ===== Quiz =====
     function startQuiz() {
+        if (!lesson) return;
+
         quiz = lesson.quiz;
         currentQ = 0;
         score = 0;
@@ -157,6 +190,7 @@
 
     // ===== Event Listeners =====
     $('btn-start-quiz').addEventListener('click', startQuiz);
+    $('btn-retry-lesson').addEventListener('click', loadLesson);
     $('btn-replay').addEventListener('click', function () {
         showScreen('learn');
     });

--- a/server/index.js
+++ b/server/index.js
@@ -321,9 +321,17 @@ app.get('/api/stock-quote', async (req, res) => {
 // ============== TURKISH DAILY LESSON API ==============
 
 app.get('/api/turkish/daily', (req, res) => {
-    const lesson = getDailyLesson();
-    const quiz = buildQuiz(lesson);
-    res.json({ id: lesson.id, topic: lesson.topic, words: lesson.words, quiz });
+    try {
+        const lesson = getDailyLesson();
+        const quiz = buildQuiz(lesson);
+        res.json({ id: lesson.id, topic: lesson.topic, words: lesson.words, quiz });
+    } catch (err) {
+        console.error('[TurkishDaily] Error:', err.message);
+        res.status(500).json({
+            error: 'turkish_daily_failed',
+            message: 'Daily lesson could not be generated.',
+        });
+    }
 });
 
 // ============== NOSTALGIABAIT CONFIG ==============


### PR DESCRIPTION
### Motivation
- The Turkish game could enter an unclear state if `GET /api/turkish/daily` failed, so the start flow needs clearer error handling and a retry path. 
- The `START QUIZ` action must be disabled until a valid `lesson` is loaded to avoid runtime errors. 
- Surface a concise, machine-friendly error shape from the server (`{ error, message }`) so the client can show useful text.

### Description
- Hardened client fetch in `games/turkish/js/game.js` by checking `res.ok` in `loadLesson()`, extracting `payload.message` when present, and setting `lesson = null` on failure. 
- Added `setLoadError()` and `setStartButtonEnabled()` helpers, guarded `startQuiz()` to return early when `lesson` is missing, and wired a retry listener to `#btn-retry-lesson`. 
- Added a compact error container (`#lesson-error` / `#lesson-error-message`) and `Erneut versuchen` retry button in `games/turkish/index.html`, plus disabled styling and default-disabled state for `#btn-start-quiz`. 
- Standardized server-side failure handling in `server/index.js` for `/api/turkish/daily` by wrapping generation in `try/catch` and returning a structured payload `{ error: 'turkish_daily_failed', message: 'Daily lesson could not be generated.' }` on error. 
- Documented the ExecPlan and recorded the change in `PLANS.md` and `HANDOFF.md`.

### Testing
- Ran syntax checks: `node --check games/turkish/js/game.js && node --check server/index.js`, which succeeded. 
- Executed an automated Playwright script that mocked a `500` response for `/api/turkish/daily` and captured a screenshot showing the error message, retry button, and disabled start button (artifact produced). 
- `npm test` could not run in this environment because `vitest` is not installed, causing the test command to fail (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ba5185a0832f9d1d8c2a23743f26)