### PR TITLE
Address review follow-ups for Turkish startup error flow

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -283,3 +283,58 @@
 
 ### Remaining
 - **~600 lines code duplication in `games/strictbrain/js/game.js`** — Each of 5 mini-games is fully duplicated for single-player and versus mode. Only difference: target DOM element IDs and score update callbacks. Works correctly but is a maintenance burden. Future refactor could parameterize game functions with `{ area, onScore, onFinish }` config objects.
+
+---
+
+# HANDOFF - Turkish Startflow Error State
+
+## What Was Done
+
+- Improved lesson loading resilience in `games/turkish/js/game.js`:
+  - Added explicit `res.ok` check before parsing successful payload.
+  - Added user-facing error state renderer (`setLoadError`) and start-button gating (`setStartButtonEnabled`).
+  - Added retry action wiring (`btn-retry-lesson`) to re-run `loadLesson()`.
+  - Ensured quiz cannot start while no lesson is loaded.
+- Added learn-screen error UI in `games/turkish/index.html`:
+  - New error container with clear message area and `Erneut versuchen` button.
+  - Start button is now disabled by default and styled for disabled state.
+- Standardized `/api/turkish/daily` failures in `server/index.js` with a structured JSON shape:
+  - `{ error: 'turkish_daily_failed', message: 'Daily lesson could not be generated.' }`
+
+## Files Changed
+
+- `games/turkish/js/game.js`
+- `games/turkish/index.html`
+- `server/index.js`
+- `PLANS.md`
+- `HANDOFF.md`
+
+## Verification
+
+- `node --check games/turkish/js/game.js`
+- `node --check server/index.js`
+- `npm test` *(fails in this environment because `vitest` is not installed)*
+- Manual browser check with mocked `500` response on `/api/turkish/daily` confirms visible error message, retry button, and disabled start button.
+
+---
+
+# HANDOFF - Turkish Startflow Follow-up (Review Addressed)
+
+## What Was Done
+
+- Updated Turkish load-failure copy in `games/turkish/js/game.js` to a clear German fallback message (`LESSON_LOAD_ERROR_MESSAGE`).
+- Adjusted learn-screen fallback labels to German (`Lektion nicht verfügbar` / `Bitte versuche es erneut.`) for a clearer local UX.
+- Restored the `PLANS.md` template checklist defaults back to unchecked values in the template section.
+
+## Files Changed
+
+- `games/turkish/js/game.js`
+- `PLANS.md`
+- `HANDOFF.md`
+
+## Verification
+
+- `node --check games/turkish/js/game.js`
+- `node --check server/index.js`
+- `npm test` *(fails in this environment because `vitest` is not installed)*
+- Browser screenshot captured with mocked `500 /api/turkish/daily` showing German error-state copy.

--- a/PLANS.md
+++ b/PLANS.md
@@ -35,3 +35,46 @@ Exact commands or manual steps to validate the change.
 
 ## Outcomes
 Summarize what shipped and what remains.
+
+---
+
+## ExecPlan - Turkish Startflow Error Handling (2026-02-07)
+
+## Purpose
+Improve the Turkish game startup UX when `/api/turkish/daily` fails by surfacing an actionable error state and allowing retry.
+
+## Scope
+- In scope: learn-screen error UI, retry action, start button disabled logic, and safer fetch error handling.
+- Optional in scope: standardize API error payload for `/api/turkish/daily` failures.
+- Out of scope: quiz mechanics, lesson content generation, visual redesign beyond minimal error container.
+
+## Context
+- `games/turkish/js/game.js`
+- `games/turkish/index.html`
+- `server/index.js`
+
+## Plan of Work
+1. Add explicit HTTP status check in `loadLesson()` and wire a reusable error-state renderer.
+2. Add learn-screen error container + retry button in HTML/CSS and connect it in JS.
+3. Disable `btn-start-quiz` while lesson is unavailable and keep it enabled only after successful load.
+4. Standardize server error response to `{ error, message }` in the Turkish daily endpoint.
+
+## Progress
+- [x] Start plan
+- [x] Implement changes
+- [x] Verify behavior
+- [x] Update handoff notes
+
+## Surprises and Discoveries
+- None yet.
+
+## Decision Log
+- Decision: Include optional server standardization because it improves client-side diagnostics with minimal risk.
+  Rationale: Single endpoint and additive JSON fields; no client break expected.
+  Date: 2026-02-07
+
+## Verification
+- Run targeted syntax checks and test suite.
+
+## Outcomes
+- Shipped client-side error handling + retry UX for Turkish lesson startup and standardized server error response payload.

--- a/games/turkish/index.html
+++ b/games/turkish/index.html
@@ -149,6 +149,45 @@
             background: var(--ds-text-dim);
         }
 
+        .btn-start:disabled {
+            background: var(--ds-highlight);
+            color: var(--ds-text-dim);
+            cursor: not-allowed;
+        }
+
+        .lesson-error {
+            display: none;
+            background: #ffe9e9;
+            border: 2px solid var(--ds-negative);
+            padding: 10px 12px;
+            margin-bottom: 12px;
+        }
+
+        .lesson-error.active {
+            display: block;
+        }
+
+        .lesson-error-message {
+            font-size: 9px;
+            color: #8e1d1d;
+            margin-bottom: 8px;
+            line-height: 1.7;
+        }
+
+        .btn-retry {
+            background: var(--ds-surface);
+            border: 2px solid var(--ds-negative);
+            color: #8e1d1d;
+            font-family: 'Press Start 2P', monospace;
+            font-size: 9px;
+            padding: 8px 10px;
+            cursor: pointer;
+        }
+
+        .btn-retry:hover {
+            background: #ffd6d6;
+        }
+
         /* Timer Bar */
         .timer-bar-wrap {
             background: var(--ds-highlight);
@@ -312,9 +351,14 @@
             <div class="lesson-day" id="lesson-day"></div>
         </div>
 
+        <div class="lesson-error" id="lesson-error">
+            <div class="lesson-error-message" id="lesson-error-message"></div>
+            <button class="btn-retry" id="btn-retry-lesson" type="button">Erneut versuchen</button>
+        </div>
+
         <div class="word-list" id="word-list"></div>
 
-        <button class="btn-start" id="btn-start-quiz">START QUIZ ▶</button>
+        <button class="btn-start" id="btn-start-quiz" disabled>START QUIZ ▶</button>
     </div>
 
     <!-- QUIZ SCREEN -->

--- a/server/index.js
+++ b/server/index.js
@@ -321,9 +321,17 @@ app.get('/api/stock-quote', async (req, res) => {
 // ============== TURKISH DAILY LESSON API ==============
 
 app.get('/api/turkish/daily', (req, res) => {
-    const lesson = getDailyLesson();
-    const quiz = buildQuiz(lesson);
-    res.json({ id: lesson.id, topic: lesson.topic, words: lesson.words, quiz });
+    try {
+        const lesson = getDailyLesson();
+        const quiz = buildQuiz(lesson);
+        res.json({ id: lesson.id, topic: lesson.topic, words: lesson.words, quiz });
+    } catch (err) {
+        console.error('[TurkishDaily] Error:', err.message);
+        res.status(500).json({
+            error: 'turkish_daily_failed',
+            message: 'Daily lesson could not be generated.',
+        });
+    }
 });
 
 // ============== NOSTALGIABAIT CONFIG ==============


### PR DESCRIPTION
### Motivation

- Ensure the Turkish lesson error UX and copy are consistent and localized by centralizing the fallback message and updating visible text when lesson load fails.
- Fix an accidental change to the `PLANS.md` template checklist that flipped checkboxes during prior edits.
- Record the review follow-ups in `HANDOFF.md` so verification steps and rationale are preserved.

### Description

- Introduced a shared fallback constant `LESSON_LOAD_ERROR_MESSAGE` and replaced the previous English fallback text with a clear German message in `games/turkish/js/game.js` so all failure branches show the same localized copy.
- Updated the learn-screen fallback labels to German (`Lektion nicht verfügbar` / `Bitte versuche es erneut.`) and ensured `lesson` is nulled and the start button is gated when load fails.
- Restored the template checkbox states in `PLANS.md` back to unchecked so the execplan template remains correct.
- Appended a focused follow-up section to `HANDOFF.md` documenting the changes and verification notes (including an error-state screenshot artifact).

### Testing

- Ran syntax checks with `node --check games/turkish/js/game.js && node --check server/index.js`, which succeeded.
- Executed a Playwright script that mocked a `500` response for `/api/turkish/daily` and produced a screenshot showing the German error state and retry button, which completed successfully (artifact produced).
- Attempted `npm test` but it failed in this environment because the `vitest` binary is not installed (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ba5185a0832f9d1d8c2a23743f26)