### PR TITLE
chore: add non-disruptive Docker self-hosting baseline, env docs and MVP checklist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+.DS_Store
+coverage
+*.local
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,34 @@
+# Network
 PORT=3000
+
+# Login/session
+SITE_PASSWORD=STRICT
+SESSION_SECRET=replace_with_secure_random_secret
+
+# Discord bot (primary var used by current runtime)
 DISCORD_TOKEN=your_discord_bot_token_here
+
+# Optional alias for future tooling compatibility
+DISCORD_BOT_TOKEN=
+
+# Discord app metadata (optional)
 CLIENT_ID=your_discord_application_id_here
 GUILD_ID=your_discord_server_id_here
-SITE_PASSWORD=STRICT
-SESSION_SECRET=your_session_secret_here
+
+# Persistence (required for production persistence)
+DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+
+# Game and feature toggles (forward-compatible)
+GAME_ENABLED=true
+GAME_START_BALANCE=1000
+GAME_PRICE_TICK_SECONDS=300
+
+# Licensing (forward-compatible)
+LICENSE_MODE=off
+LICENSE_KEY=
+
+# Nostalgia video IDs (optional)
 NOSTALGIA_PS1_YOUTUBE_ID=your_youtube_video_id_here
 NOSTALGIA_PS2_YOUTUBE_ID=your_youtube_video_id_here
 NOSTALGIA_GAMECUBE_YOUTUBE_ID=your_youtube_video_id_here
 NOSTALGIA_WIISSBB_YOUTUBE_ID=your_youtube_video_id_here
-DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -305,3 +305,56 @@
 
 - `node --check games/turkish/js/game.js`
 
+
+---
+
+# HANDOFF - MVP Umsetzungs-Checkliste (Self-hosted Stock-Game)
+
+## What Was Done
+
+- Added `docs/mvp-umsetzungs-checkliste.md` with a concrete, file-by-file implementation plan for the agreed MVP direction:
+  - Self-hosted-first setup hardening
+  - Stock command validation
+  - Leaderboard/net-worth consistency
+  - ENV feature toggles
+  - Lightweight license-key flow
+  - Minimal conversion tracking events
+- Included per-step DoD and explicit verification commands to support small PR sequencing.
+
+## Files Changed
+
+- `docs/mvp-umsetzungs-checkliste.md`
+- `HANDOFF.md`
+
+## Verification
+
+- Reviewed checklist structure and command list for consistency with current repo modules.
+
+---
+
+# HANDOFF - PR #1 Self-hosting Baseline (Docker + Docs)
+
+## What Was Done
+
+- Added containerization baseline without touching game or socket logic:
+  - `Dockerfile` for production-style Node runtime
+  - `.dockerignore` to keep image context small and avoid leaking local env files
+  - `docker-compose.yml` for one-command startup and `/health` healthcheck
+- Expanded `.env.example` with clearer required/optional grouping and forward-compatible keys (`GAME_*`, `LICENSE_*`) while keeping current `DISCORD_TOKEN` behavior intact.
+- Updated `README.md` with a Docker quickstart and a short troubleshooting section (bot token, DB URL, host port conflict).
+- Updated `PLANS.md` with an ExecPlan section for this multi-file setup task and recorded outcomes.
+
+## Files Changed
+
+- `Dockerfile`
+- `.dockerignore`
+- `docker-compose.yml`
+- `.env.example`
+- `README.md`
+- `PLANS.md`
+- `HANDOFF.md`
+
+## Verification
+
+- Attempted: `docker compose config` (environment limitation: docker not installed in this runtime)
+- Attempted: `npm test` (environment limitation: `vitest` binary missing because dependencies are not installed in this runtime)

--- a/PLANS.md
+++ b/PLANS.md
@@ -35,3 +35,48 @@ Exact commands or manual steps to validate the change.
 
 ## Outcomes
 Summarize what shipped and what remains.
+
+---
+
+## ExecPlan - PR #1 Self-hosting Baseline
+
+## Purpose
+Add a non-disruptive Docker-based quickstart so community owners can run StrictHotel with copy/paste setup.
+
+## Scope
+In scope: containerization docs and env template improvements.
+Out of scope: game logic, socket behavior, licensing logic.
+
+## Context
+- `server.js`, `server/index.js` start path
+- `README.md` onboarding docs
+- `.env.example` runtime configuration sample
+
+## Plan of Work
+1. Add `Dockerfile` and `.dockerignore` with a production-safe Node runtime.
+2. Add `docker-compose.yml` for one-command local bring-up.
+3. Expand `.env.example` with clear required/optional keys while keeping backward compatibility.
+4. Update `README.md` with docker quickstart and troubleshooting notes.
+5. Run basic verification commands.
+
+## Progress
+- [x] Start plan
+- [x] Implement changes
+- [x] Verify behavior
+- [x] Update handoff notes
+
+## Surprises and Discoveries
+- Existing runtime already exposes `/health`, making container health checks straightforward.
+
+## Decision Log
+- Decision: Keep `DISCORD_TOKEN` as primary env var and document `DISCORD_BOT_TOKEN` as optional alias for future compatibility.
+  Rationale: Avoid disrupting current bot startup logic in `server/discord-bot.js`.
+  Date: 2026-02-08
+
+## Verification
+- `docker compose config`
+- `npm test`
+
+## Outcomes
+Shipped non-disruptive containerization assets and updated setup docs.
+Verification was attempted; docker is unavailable in this environment and `vitest` is missing, so runtime checks are documented as environment-limited warnings.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ npm run dev
 ```
 Server runs at `http://localhost:3000`.
 
+## Self-Hosted Quickstart (Docker)
+1. Copy env template and fill required values:
+   ```bash
+   cp .env.example .env
+   ```
+2. Build and start:
+   ```bash
+   docker compose up -d --build
+   ```
+3. Open `http://localhost:3000`.
+4. Health check:
+   ```bash
+   docker compose ps
+   curl http://localhost:3000/health
+   ```
+
+### Troubleshooting
+- **Bot not starting**: ensure `DISCORD_TOKEN` is set in `.env`.
+- **Database errors**: verify `DATABASE_URL` format and DB network access.
+- **Port already in use**: change host mapping in `docker-compose.yml` (left side of `3000:3000`).
+
 ## Configuration (Env)
 - `SESSION_SECRET` (required in production)
 - `SITE_PASSWORD` (login password, default: ADMIN)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  stricthotel:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/docs/mvp-umsetzungs-checkliste.md
+++ b/docs/mvp-umsetzungs-checkliste.md
@@ -1,0 +1,158 @@
+# MVP Umsetzungs-Checkliste (Self-Hosted Stock-Game)
+
+Ziel: In kleinen, risikoarmen Schritten von der aktuellen Codebase zu einem verkaufbaren v1-MVP kommen (Self-hosted first, Conversion zu zahlend als Haupt-KPI).
+
+## Scope (v1)
+
+- Enthalten: Setup in ~10 Minuten, Stock-Commands, Leaderboard/Net-Worth, Feature-Toggles, einfacher Lizenz-Check.
+- Nicht enthalten: Plugin-System, Seasons, große Admin-UI.
+
+---
+
+## Schritt 1 - Self-hosting-Baseline auf 10-Minuten-Ziel bringen
+
+### Dateien
+- `Dockerfile` (neu)
+- `docker-compose.yml` (neu)
+- `.env.example` (neu)
+- `README.md`
+
+### To-do
+- Node Runtime + Start Command in Docker sauber definieren.
+- `docker compose up -d` als Standardpfad dokumentieren.
+- Pflicht-Variablen in `.env.example` mit Kommentaren bereitstellen:
+  - `DISCORD_BOT_TOKEN`, `DATABASE_URL`, `PORT`
+  - `GAME_ENABLED`, `GAME_START_BALANCE`, `GAME_PRICE_TICK_SECONDS`
+  - `LICENSE_KEY`, `LICENSE_MODE`
+- Troubleshooting-Miniblock in `README.md` (Bot offline, DB nicht erreichbar, Port belegt).
+
+### DoD
+- Ein neuer Owner kann mit Copy/Paste-Schritten lokal starten.
+
+### Checks
+- `docker compose config`
+- `docker compose up -d`
+- `docker compose logs --tail=100`
+
+---
+
+## Schritt 2 - Stock-Commands serverseitig haerten
+
+### Dateien
+- `server/socket-handlers.js`
+- `server/stock-game.js`
+- Optional: `games/stocks/js/game.js` (nur falls Fehlermeldungen/UI-States fehlen)
+
+### To-do
+- Fuer Buy/Sell nur positive Ganzzahlen akzeptieren.
+- Balance/Holdings niemals negativ werden lassen.
+- Fehlerpfade vereinheitlichen (konsistente Error-Events/Message-Shape).
+- Cooldown oder leichtes Rate-Limit fuer Trade-Spam pruefen (falls noch nicht vorhanden).
+
+### DoD
+- Ungueltige Inputs und Grenzfaelle werden sauber geblockt.
+
+### Checks
+- `npm test`
+- Manueller Socket-Flow: buy/sell mit validen und invaliden Werten
+
+---
+
+## Schritt 3 - Leaderboard und Net-Worth als Kern-Hook absichern
+
+### Dateien
+- `server/stock-game.js`
+- `server/socket-handlers.js`
+- Optional Anzeige: `games/stocks/js/game.js`
+
+### To-do
+- Net-Worth einheitlich berechnen: `cash + sum(position_qty * current_price)`.
+- `/top` bzw. leaderboard-Event auf stabile Sortierung trimmen.
+- Leere Datensaetze/Null-Portfolios robust behandeln.
+
+### DoD
+- Top-Liste ist nachvollziehbar und konsistent mit Portfolio-Werten.
+
+### Checks
+- `npm test`
+- Manuell mit 2-3 Testaccounts: unterschiedliche Portfolios handeln und Reihenfolge verifizieren
+
+---
+
+## Schritt 4 - Feature-Toggles sauber ueber ENV
+
+### Dateien
+- `server.js`
+- `server/socket-handlers.js`
+- `.env.example`
+- `README.md`
+
+### To-do
+- `GAME_ENABLED` zentral auslesen und weiterreichen.
+- Wenn deaktiviert: klare Serverantwort statt stiller Fehler.
+- README-Doku: welche Features per ENV schaltbar sind.
+
+### DoD
+- Stock-Feature kann ohne Codeaenderung an/aus geschaltet werden.
+
+### Checks
+- `GAME_ENABLED=false npm start`
+- Trade-Events pruefen (korrekte deaktiviert-Meldung)
+
+---
+
+## Schritt 5 - Lizenz-Key MVP (leichtgewichtig)
+
+### Dateien
+- `server.js`
+- Optional neu: `server/license.js`
+- `.env.example`
+- `README.md`
+
+### To-do
+- `LICENSE_MODE`: `required | trial | off`.
+- Bei `required` Start verweigern, falls `LICENSE_KEY` fehlt/ungueltig.
+- Bei `trial` klare Start-Logmeldung inkl. Ablaufhinweis.
+- Simple erste Validierung (zunaechst lokal-konfigurierbar), spaeter externe Verifikation.
+
+### DoD
+- Kauf-/Key-Flow ist technisch abbildbar ohne manuelle Codeeingriffe beim Owner.
+
+### Checks
+- `LICENSE_MODE=required` ohne Key -> erwarteter Startfehler
+- `LICENSE_MODE=off` -> normaler Start
+
+---
+
+## Schritt 6 - Conversion-Messpunkte (minimal)
+
+### Dateien
+- `server/socket-handlers.js`
+- Optional neu: `server/metrics.js`
+- `HANDOFF.md` (Verifikationsnotizen pro Release)
+
+### To-do
+- Drei Kernereignisse loggen (zunaechst serverseitig):
+  - Installation/Start
+  - First trade pro Guild
+  - Aktiver Server pro Tag
+- Logs so strukturieren, dass spaetere Auswertung einfach bleibt.
+
+### DoD
+- Conversion-Trichter ist mit minimalem Logging nachvollziehbar.
+
+### Checks
+- Start + 1 Trade ausloesen und Logs auf erwartete Eventstruktur pruefen
+
+---
+
+## Reihenfolge-Empfehlung fuer PRs
+
+1. PR #1: Setup (Docker + `.env.example` + README)
+2. PR #2: Stock-Validierung + Error-Shapes
+3. PR #3: Leaderboard/Net-Worth Konsistenz
+4. PR #4: Feature-Toggles
+5. PR #5: Lizenz-Key MVP
+6. PR #6: Conversion-Logging
+
+Jede PR klein halten, mit klarer Verifikation in `HANDOFF.md` dokumentieren.


### PR DESCRIPTION
### Motivation

- Provide a copy/paste self-hosting quickstart so owners can run StrictHotel locally in minutes without touching game logic. 
- Keep runtime behavior non-disruptive and backwards-compatible by preserving existing env usage (e.g. `DISCORD_TOKEN` remains the primary bot token variable). 
- Record the multi-file plan and next-steps as an ExecPlan and a concrete MVP checklist to support a small-PR rollout.

### Description

- Added containerization assets: `Dockerfile`, `.dockerignore`, and `docker-compose.yml` with a `/health` healthcheck and `3000:3000` mapping. 
- Expanded `.env.example` with clearer required/optional grouping and forward-compatible keys (`GAME_*`, `LICENSE_*`) while keeping current vars intact. 
- Updated `README.md` with a Docker quickstart and a short troubleshooting block. 
- Added orchestration and process notes: updated `PLANS.md` (ExecPlan for PR #1), appended verification/handoff notes to `HANDOFF.md`, and added `docs/mvp-umsetzungs-checkliste.md` (MVP rollout checklist); no game or socket logic was modified.

### Testing

- Ran `docker compose config` as a verification step but it failed because `docker` is not available in this runtime environment (automated check failed). 
- Ran `npm test` to exercise unit/test tooling but it failed because the `vitest` binary was not available in the environment (automated check failed). 
- Attempted `npm install` to provision dependencies but the environment produced warnings and did not produce a usable `vitest` test run, so test execution is environment-limited (no passing automated tests possible here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ba9e5978832f82f6d13abc8ab50d)