### PR TITLE
feat: Harden stock trade validation and standardize `stock-error` payloads

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -358,3 +358,28 @@
 
 - Attempted: `docker compose config` (environment limitation: docker not installed in this runtime)
 - Attempted: `npm test` (environment limitation: `vitest` binary missing because dependencies are not installed in this runtime)
+
+---
+
+# HANDOFF - PR #2 Stock Command Hardening
+
+## What Was Done
+
+- Hardened stock trade input validation to accept only positive integer trade amounts for `stock-buy` and `stock-sell`.
+- Added a lightweight per-socket stock trade cooldown (400ms) to reduce trade-spam bursts.
+- Standardized stock error payloads via `{ code, message, error }` so clients can use structured codes while keeping backward compatibility with existing `error` handling.
+- Extended stock engine error returns in `server/stock-game.js` with stable error `code` values (e.g. `INVALID_AMOUNT`, `INSUFFICIENT_FUNDS`, `NOT_ENOUGH_SHARES`, `TRANSACTION_FAILED`).
+- Cleans up trade cooldown state on socket disconnect.
+
+## Files Changed
+
+- `server/socket-handlers.js`
+- `server/stock-game.js`
+- `HANDOFF.md`
+
+## Verification
+
+- `node --check server/socket-handlers.js`
+- `node --check server/stock-game.js`
+- `npm test`
+

--- a/server/socket-handlers.js
+++ b/server/socket-handlers.js
@@ -57,9 +57,27 @@ function validateYouTubeId(videoId) {
     return videoId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 11);
 }
 
+function parseTradeAmount(rawAmount) {
+    const amount = Number(rawAmount);
+    if (!Number.isFinite(amount) || !Number.isInteger(amount) || amount <= 0) {
+        return null;
+    }
+    return amount;
+}
+
+function emitStockError(socket, code, message) {
+    socket.emit('stock-error', {
+        code,
+        message,
+        // Backward compatibility for clients reading `error`
+        error: message
+    });
+}
+
 // ============== RATE LIMITING ==============
 
 const rateLimiters = new Map(); // socketId -> { count, resetTime }
+const stockTradeCooldown = new Map(); // socketId -> timestamp
 
 function checkRateLimit(socketId, maxPerSecond = 10) {
     const now = Date.now();
@@ -70,6 +88,14 @@ function checkRateLimit(socketId, maxPerSecond = 10) {
     }
     entry.count++;
     return entry.count <= maxPerSecond;
+}
+
+function checkStockTradeCooldown(socketId, minIntervalMs = 400) {
+    const now = Date.now();
+    const lastTradeAt = stockTradeCooldown.get(socketId) || 0;
+    if (now - lastTradeAt < minIntervalMs) return false;
+    stockTradeCooldown.set(socketId, now);
+    return true;
 }
 
 // ============== SOUNDBOARD STATE ==============
@@ -344,12 +370,16 @@ export function registerSocketHandlers(io, { fetchTickerQuotes, getYahooFinance 
             const symbol = typeof data.symbol === 'string'
                 ? data.symbol.replace(/[^A-Z0-9.\-=]/g, '').slice(0, 12) : '';
             if (!symbol) {
-                socket.emit('stock-error', { error: 'Invalid symbol' });
+                emitStockError(socket, 'INVALID_SYMBOL', 'Invalid symbol');
                 return;
             }
-            const amount = Number(data.amount);
-            if (!Number.isFinite(amount) || amount <= 0) {
-                socket.emit('stock-error', { error: 'Invalid amount' });
+            const amount = parseTradeAmount(data.amount);
+            if (amount === null) {
+                emitStockError(socket, 'INVALID_AMOUNT', 'Amount must be a positive integer');
+                return;
+            }
+            if (!checkStockTradeCooldown(socket.id)) {
+                emitStockError(socket, 'TRADE_COOLDOWN', 'Trade requests are too fast');
                 return;
             }
 
@@ -370,13 +400,13 @@ export function registerSocketHandlers(io, { fetchTickerQuotes, getYahooFinance 
                 } catch (e) { /* symbol not found */ }
             }
             if (!quote) {
-                socket.emit('stock-error', { error: 'Price unavailable' });
+                emitStockError(socket, 'PRICE_UNAVAILABLE', 'Price unavailable');
                 return;
             }
 
             const result = await buyStock(player.name, quote.symbol, quote.price, amount);
             if (!result.ok) {
-                socket.emit('stock-error', { error: result.error });
+                emitStockError(socket, result.code || 'BUY_FAILED', result.error || 'Buy failed');
                 return;
             }
 
@@ -395,12 +425,16 @@ export function registerSocketHandlers(io, { fetchTickerQuotes, getYahooFinance 
             const symbol = typeof data.symbol === 'string'
                 ? data.symbol.replace(/[^A-Z0-9.\-=]/g, '').slice(0, 12) : '';
             if (!symbol) {
-                socket.emit('stock-error', { error: 'Invalid symbol' });
+                emitStockError(socket, 'INVALID_SYMBOL', 'Invalid symbol');
                 return;
             }
-            const amount = Number(data.amount);
-            if (!Number.isFinite(amount) || amount <= 0) {
-                socket.emit('stock-error', { error: 'Invalid amount' });
+            const amount = parseTradeAmount(data.amount);
+            if (amount === null) {
+                emitStockError(socket, 'INVALID_AMOUNT', 'Amount must be a positive integer');
+                return;
+            }
+            if (!checkStockTradeCooldown(socket.id)) {
+                emitStockError(socket, 'TRADE_COOLDOWN', 'Trade requests are too fast');
                 return;
             }
 
@@ -420,13 +454,13 @@ export function registerSocketHandlers(io, { fetchTickerQuotes, getYahooFinance 
                 } catch (e) { /* symbol not found */ }
             }
             if (!quote) {
-                socket.emit('stock-error', { error: 'Price unavailable' });
+                emitStockError(socket, 'PRICE_UNAVAILABLE', 'Price unavailable');
                 return;
             }
 
             const result = await sellStock(player.name, quote.symbol, quote.price, amount);
             if (!result.ok) {
-                socket.emit('stock-error', { error: result.error });
+                emitStockError(socket, result.code || 'SELL_FAILED', result.error || 'Sell failed');
                 return;
             }
 
@@ -1568,6 +1602,7 @@ export function registerSocketHandlers(io, { fetchTickerQuotes, getYahooFinance 
         socket.on('disconnect', async () => { try {
             // Cleanup rate limiter
             rateLimiters.delete(socket.id);
+            stockTradeCooldown.delete(socket.id);
 
             cleanupPictoForSocket(socket.id, io);
             io.to(PICTO_ROOM).emit('picto-cursor-hide', { id: socket.id });


### PR DESCRIPTION
### Motivation
- Prevent invalid or abusive stock trade requests by enforcing stricter server-side validation and a light cooldown. 
- Provide a stable, structured error shape so clients can handle trade failures reliably while remaining backward-compatible. 
- Align with the MVP checklist step for server-side hardening of stock commands and make error codes available from the engine. 

### Description
- Added `parseTradeAmount`, `emitStockError`, and `checkStockTradeCooldown` helpers and a `stockTradeCooldown` map to `server/socket-handlers.js` to validate integer amounts, emit structured `{ code, message, error }` errors, and throttle rapid trades. 
- Replaced inline validation in `stock-buy` and `stock-sell` socket handlers to use the new helpers and to return consistent error codes for `INVALID_SYMBOL`, `INVALID_AMOUNT`, `TRADE_COOLDOWN`, and `PRICE_UNAVAILABLE`. 
- Hardened the stock engine in `server/stock-game.js` so `buyStock`/`sellStock` require positive integer `amount` values and return error objects with stable `code` values (e.g. `INVALID_AMOUNT`, `INVALID_PRICE`, `INSUFFICIENT_FUNDS`, `NO_SHARES`, `NOT_ENOUGH_SHARES`, `TRANSACTION_FAILED`). 
- Cleaned up per-socket cooldown state on disconnect and documented the change in `HANDOFF.md` under “PR #2 Stock Command Hardening”. 

### Testing
- Syntax checks passed with `node --check server/socket-handlers.js` and `node --check server/stock-game.js`. 
- Automated test suite ran with `npm test` and all tests passed (`4` test files, `54` tests total). 
- Manual validation notes recorded in `HANDOFF.md` for reviewers to follow up (verification commands: `node --check` and `npm test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987d74fb25c832fad9bf81c5c3e9502)